### PR TITLE
mailer SSL compatibility with Python 3

### DIFF
--- a/repoze/sendmail/mailer.py
+++ b/repoze/sendmail/mailer.py
@@ -14,7 +14,7 @@
 from email.message import Message
 from smtplib import SMTP
 try:
-    from socket import ssl
+    import ssl
 except ImportError: #pragma NO COVER
     HAVE_SSL = False
 else: #pragma NO COVER


### PR DESCRIPTION
I was running into an issue with Python 3.2. I'm using `pyramid_mailer` package, but the issue is located in [repoze.sendmail.mailer](https://github.com/repoze/repoze.sendmail/blob/master/repoze/sendmail/mailer.py#L71). When attempting to send mail against a TLS mail server [I receive an exception](https://gist.github.com/2785577). The SMTP connection never starts TLS (via `connection.starttls`) because the `HAVE_SSL` constant is set to `False`. I have SSL support in my Python3 install. If I manual set `HAVE_SSL` to `True` the email I'm trying to send is successful. Also, this is [the recommend test](http://docs.python.org/dev/library/ssl.html#testing-for-ssl-support) according to the standard library docs.
