### PR TITLE
FIX: Python3 transactions and sqlalchemy conflict

### DIFF
--- a/repoze/sendmail/delivery.py
+++ b/repoze/sendmail/delivery.py
@@ -47,7 +47,7 @@ class MailDataManager(object):
             self.onAbort()
 
     def sortKey(self):
-        return id(self)
+        return str(id(self))
 
     # No subtransaction support.
     def abort_sub(self, transaction):


### PR DESCRIPTION
When used together with transaction and sqlalchemy,
it results in TypeErrorTypeError: unorderable types: int() < str().
SQLAlchemy uses string as sortKey while this uses int as sortKey
and these just does not work together in python3.
