### PR TITLE
Replace `utf_8` and `latin_1` encoding names for prefered `utf-8` and `iso-8859-1`.

### DIFF
--- a/repoze/sendmail/encoding.py
+++ b/repoze/sendmail/encoding.py
@@ -27,14 +27,14 @@ def cleanup_message(message,
     Cleanup a `Message` handling header and payload charsets.
 
     Headers are handled in the most sane way possible.  Address names
-    are left in `ascii` if possible or encoded to `latin_1` or `utf-8`
+    are left in `ascii` if possible or encoded to `iso-8859-1` or `utf-8`
     and finally encoded according to RFC 2047 without encoding the
     address, something the `email` stdlib package doesn't do.
     Parameterized headers such as `filename` in the
     `Content-Disposition` header, have their values encoded properly
     while leaving the rest of the header to be handled without
     encoding.  Finally, all other header are left in `ascii` if
-    possible or encoded to `latin_1` or `utf-8` as a whole.
+    possible or encoded to `iso-8859-1` or `utf-8` as a whole.
 
     The message is modified in place and is also returned in such a
     state that it can be safely encoded to ascii.
@@ -86,14 +86,14 @@ def encode_message(message,
     Encode a `Message` handling headers and payloads.
 
     Headers are handled in the most sane way possible.  Address names
-    are left in `ascii` if possible or encoded to `latin_1` or `utf-8`
+    are left in `ascii` if possible or encoded to `iso-8859-1` or `utf-8`
     and finally encoded according to RFC 2047 without encoding the
     address, something the `email` stdlib package doesn't do.
     Parameterized headers such as `filename` in the
     `Content-Disposition` header, have their values encoded properly
     while leaving the rest of the header to be handled without
     encoding.  Finally, all other header are left in `ascii` if
-    possible or encoded to `latin_1` or `utf-8` as a whole.
+    possible or encoded to `iso-8859-1` or `utf-8` as a whole.
 
     The return is a byte string of the whole message.
     """
@@ -105,10 +105,10 @@ def best_charset(text):
     """
     Find the most human-readable and/or conventional encoding for unicode text.
 
-    Prefers `ascii` or `latin_1` and falls back to `utf_8`.
+    Prefers `ascii` or `iso-8859-1` and falls back to `utf-8`.
     """
     encoded = text
-    for charset in 'ascii', 'latin_1', 'utf_8':
+    for charset in 'ascii', 'iso-8859-1', 'utf-8':
         try:
             encoded = text.encode(charset)
         except UnicodeError:

--- a/repoze/sendmail/tests/test_encoding.py
+++ b/repoze/sendmail/tests/test_encoding.py
@@ -30,15 +30,15 @@ class Test_best_charset(unittest.TestCase):
     def test_w_latin_1(self):
         from repoze.sendmail._compat import b
         latin_1_encoded = b('LaPe\xf1a')
-        best, encoded = self._callFUT(latin_1_encoded.decode('latin_1'))
-        self.assertEqual(best, 'latin_1')
+        best, encoded = self._callFUT(latin_1_encoded.decode('iso-8859-1'))
+        self.assertEqual(best, 'iso-8859-1')
         self.assertEqual(encoded, latin_1_encoded)
 
     def test_w_utf_8(self):
         from repoze.sendmail._compat import b
         utf_8_encoded = b('mo \xe2\x82\xac')
-        best, encoded = self._callFUT(utf_8_encoded.decode('utf_8'))
-        self.assertEqual(best, 'utf_8')
+        best, encoded = self._callFUT(utf_8_encoded.decode('utf-8'))
+        self.assertEqual(best, 'utf-8')
         self.assertEqual(encoded, utf_8_encoded)
 
 
@@ -74,7 +74,7 @@ class TestEncoding(unittest.TestCase):
     def test_encoding_latin_1_headers(self):
         from repoze.sendmail._compat import b
         latin_1_encoded = b('LaPe\xf1a')
-        latin_1 = latin_1_encoded.decode('latin_1')
+        latin_1 = latin_1_encoded.decode('iso-8859-1')
         to = ', '.join([
             '"' + latin_1 + ' McDonough, M.D." <chrism@example.com>',
             'Chris Rossi <chrisr@example.com>'])
@@ -97,7 +97,7 @@ class TestEncoding(unittest.TestCase):
     def test_encoding_utf_8_headers(self):
         from repoze.sendmail._compat import b
         utf_8_encoded = b('mo \xe2\x82\xac')
-        utf_8 = utf_8_encoded.decode('utf_8')
+        utf_8 = utf_8_encoded.decode('utf-8')
         to = ', '.join([
             '"' + utf_8 + ' McDonough, M.D." <chrism@example.com>',
             'Chris Rossi <chrisr@example.com>'])
@@ -110,9 +110,9 @@ class TestEncoding(unittest.TestCase):
 
         encoded = self._callFUT(message)
 
-        self.assertTrue(b('To: =?utf') in encoded)
-        self.assertTrue(b('From: =?utf') in encoded)
-        self.assertTrue(b('Subject: =?utf') in encoded)
+        self.assertTrue(b('To: =?utf-8?') in encoded)
+        self.assertTrue(b('From: =?utf-8?') in encoded)
+        self.assertTrue(b('Subject: =?utf-8?') in encoded)
         self.assertTrue(b('<chrism@example.com>') in encoded)
         self.assertTrue(b('<chrisr@example.com>') in encoded)
         self.assertTrue(b('<rpatterson@example.com>') in encoded)
@@ -132,7 +132,7 @@ class TestEncoding(unittest.TestCase):
         from repoze.sendmail._compat import b
         from repoze.sendmail._compat import quote
         latin_1_encoded = b('LaPe\xf1a')
-        latin_1 = latin_1_encoded.decode('latin_1')
+        latin_1 = latin_1_encoded.decode('iso-8859-1')
         message = self._makeMessage()
         message['Content-Disposition'] = (
             'attachment; filename=' + latin_1 + '.ppt')
@@ -141,14 +141,14 @@ class TestEncoding(unittest.TestCase):
         
         self.assertTrue(
             b("Content-Disposition: attachment; filename*=") in encoded)
-        self.assertTrue(b("latin_1''") + quote(latin_1_encoded).encode('ascii')
+        self.assertTrue(b("iso-8859-1''") + quote(latin_1_encoded).encode('ascii')
                         in encoded)
     
     def test_encoding_utf_8_header_parameters(self):
         from repoze.sendmail._compat import b
         from repoze.sendmail._compat import quote
         utf_8_encoded = b('mo \xe2\x82\xac')
-        utf_8 = utf_8_encoded.decode('utf_8')
+        utf_8 = utf_8_encoded.decode('utf-8')
         message = self._makeMessage()
         message['Content-Disposition'] = (
             'attachment; filename=' + utf_8 +'.ppt')
@@ -157,7 +157,7 @@ class TestEncoding(unittest.TestCase):
         
         self.assertTrue(
             b("Content-Disposition: attachment; filename*=") in encoded)
-        self.assertTrue(b("utf_8''") + quote(utf_8_encoded).encode('ascii')
+        self.assertTrue(b("utf-8''") + quote(utf_8_encoded).encode('ascii')
                         in encoded)
 
     def test_encoding_ascii_body(self):
@@ -173,27 +173,27 @@ class TestEncoding(unittest.TestCase):
         import quopri
         from repoze.sendmail._compat import b
         latin_1_encoded = b('LaPe\xf1a')
-        latin_1 = latin_1_encoded.decode('latin_1')
+        latin_1 = latin_1_encoded.decode('iso-8859-1')
         body = 'I know what you did last ' + latin_1
         message = self._makeMessage()
         message.set_payload(body)
 
         encoded = self._callFUT(message)
 
-        self.assertTrue(quopri.encodestring(body.encode('latin_1')) in encoded)
+        self.assertTrue(quopri.encodestring(body.encode('iso-8859-1')) in encoded)
 
     def test_encoding_utf_8_body(self):
         from repoze.sendmail._compat import b
         from repoze.sendmail._compat import encodestring
         utf_8_encoded = b('mo \xe2\x82\xac')
-        utf_8 = utf_8_encoded.decode('utf_8')
+        utf_8 = utf_8_encoded.decode('utf-8')
         body = 'I know what you did last '+ utf_8
         message = self._makeMessage()
         message.set_payload(body)
 
         encoded = self._callFUT(message)
 
-        self.assertTrue(encodestring(body.encode('utf_8')) in encoded)
+        self.assertTrue(encodestring(body.encode('utf-8')) in encoded)
 
     def test_binary_body(self):
         from email.mime import application
@@ -219,7 +219,7 @@ class TestEncoding(unittest.TestCase):
         message = multipart.MIMEMultipart('alternative')
 
         utf_8_encoded = b('mo \xe2\x82\xac')
-        utf_8 = utf_8_encoded.decode('utf_8')
+        utf_8 = utf_8_encoded.decode('utf-8')
 
         plain_string = utf_8
         plain_part = nonmultipart.MIMENonMultipart('plain', 'plain')
@@ -238,6 +238,6 @@ class TestEncoding(unittest.TestCase):
 
         encoded = self._callFUT(message)
 
-        self.assertTrue(encodestring(plain_string.encode('utf_8')) in encoded)
-        self.assertTrue(encodestring(html_string.encode('utf_8')) in encoded)
+        self.assertTrue(encodestring(plain_string.encode('utf-8')) in encoded)
+        self.assertTrue(encodestring(html_string.encode('utf-8')) in encoded)
         self.assertTrue(binary_b64 in encoded)


### PR DESCRIPTION
Some email clients do not recognize utf_8 as the valid encoding, and according to the http://www.ietf.org/rfc/rfc3629, only valid name for the encoding is utf-8.
