### PR TITLE
Encode message before sending it to sendmail

### DIFF
--- a/repoze/sendmail/mailer.py
+++ b/repoze/sendmail/mailer.py
@@ -174,6 +174,9 @@ class SendmailMailer(object):
                            recipients=toaddrs)
                 for arg in self.sendmail_template] + list(toaddrs)
         p = self._popen(args)
+
+        message = message.encode()
+
         stdoutdata, stderrdata = p.communicate(message)
         if p.returncode:
             raise subprocess.CalledProcessError(


### PR DESCRIPTION
In python3, communication with process must be in bytes, but message
is a string here. So we can force encode the message here.

In Python2, the result is still a string, in Python3 we have bytes
that we can pass to subprocess.
