### PR TITLE
Make MailDataManager more lenient about when abort may be called

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,13 @@ Unreleased
   failed-commit situations (masking the original exception
   responsible for the failed transaction.)
 
+- ``MailDataManger`` now sends mail from ``tpc_vote`` rather than
+  ``tpc_finish``.  According to the `transaction documentation`_,
+  ``tpc_finish`` should never fail.
+
+.. _transaction documentation:
+   https://zodb.readthedocs.org/en/latest/transactions.html#tpc-finish
+
 4.2 (2014-02-17)
 ----------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ Unreleased
 
 - Add support for Python 3.4, PyPy3.
 
+- ``MailDataManager.abort`` and ``MailDataManager.tpc_abort`` are now
+  more lenient regarding when they may be called in the transaction
+  life-cycle.  They were raising exceptions in some normal
+  failed-commit situations (masking the original exception
+  responsible for the failed transaction.)
+
 4.2 (2014-02-17)
 ----------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -112,3 +112,5 @@ Contributors
 - Jonathan Vanasco, 2013/03/19
 
 - Patrick Strawderman, 2013/11/15
+
+- Geoffrey T. Dairiki, 2015/06/30

--- a/repoze/sendmail/tests/test_delivery.py
+++ b/repoze/sendmail/tests/test_delivery.py
@@ -122,7 +122,7 @@ class TestMailDataManager(unittest.TestCase):
         txn = DummyTransaction()
         mdm.join_transaction(txn)
         mdm.tpc_phase = 1
-        self.assertRaises(ValueError, mdm.abort, txn)
+        mdm.abort(txn) # no raise
 
     def test_abort_w_same_transaction(self):
         mdm = self._makeOne(object)
@@ -265,10 +265,12 @@ class TestMailDataManager(unittest.TestCase):
         self.assertRaises(ValueError, mdm.tpc_abort, txn2)
 
     def test_tpc_abort_not_already_tpc(self):
+        from ..delivery import MailDataManagerState
         mdm = self._makeOne()
         txn = DummyTransaction()
         mdm.join_transaction(txn)
-        self.assertRaises(ValueError, mdm.tpc_abort, txn)
+        mdm.tpc_abort(txn)
+        self.assertEqual(mdm.state, MailDataManagerState.TPC_ABORTED)
 
     def test_tpc_abort_already_finished(self):
         from ..delivery import MailDataManagerState

--- a/repoze/sendmail/tests/test_transaction.py
+++ b/repoze/sendmail/tests/test_transaction.py
@@ -2,6 +2,7 @@ import logging
 import unittest
 
 from repoze.sendmail.delivery import DirectMailDelivery
+import transaction
 from email.message import Message
 
 
@@ -9,11 +10,9 @@ from email.message import Message
 class TestTransactionMails(unittest.TestCase):
 
     def setUp(self):
-        import transaction
         transaction.begin()
 
     def test_abort(self):
-        import transaction
         mailer = _makeMailerStub()
         delivery = DirectMailDelivery(mailer)
 
@@ -28,7 +27,6 @@ class TestTransactionMails(unittest.TestCase):
 
 
     def test_doom(self):
-        import transaction
         mailer = _makeMailerStub()
         delivery = DirectMailDelivery(mailer)
 
@@ -45,8 +43,6 @@ class TestTransactionMails(unittest.TestCase):
 
 
     def test_savepoint(self):
-        import transaction
-        
         mailer = _makeMailerStub()
         delivery = DirectMailDelivery(mailer)
         ( fromaddr , toaddrs ) = fromaddr_toaddrs()
@@ -110,7 +106,7 @@ class TestTransactionMails(unittest.TestCase):
     def test_abort_after_failed_commit(self):
         # It should be okay to call transaction.abort() after a failed
         # commit.  (E.g. pyramid_tm does this.)
-        import transaction
+
         mailer = _makeMailerStub(_failing=True)
         delivery = DirectMailDelivery(mailer)
         fromaddr, toaddrs = fromaddr_toaddrs()
@@ -127,7 +123,7 @@ class TestTransactionMails(unittest.TestCase):
         # If there is a failure during transaction.commit() before all
         # data managers have voted, .abort() is called on the non-voted
         # managers before their .tpc_finish() is called.
-        import transaction
+
         mailer = _makeMailerStub()
         delivery = DirectMailDelivery(mailer)
         fromaddr, toaddrs = fromaddr_toaddrs()


### PR DESCRIPTION
The checks that `MailDataManager.abort` and `.tcp_abort` perform regarding when in the transaction life-cycle they may be called are too strict.  They raise exceptions during certain scenarios involving failed commits. When that happens those exceptions replace/mask the underlying exception responsible for the commit failure, which make troubleshooting difficult.

This fixes that.

====

Additionally, the last commit in this series (87e857294410057e0284d43c11551be2a08c96e2), moves the sending of email from `tcp_finish` to `tcp_vote`.  Justifications for this:

- The [transaction docs](https://zodb.readthedocs.org/en/latest/transactions.html#tpc-finish) state that `tpc_finish` “should never fail”.  
- When a `tcp_finish` does raise an exception, [transaction](https://github.com/zopefoundation/transaction/blob/c51b064b0f219f2d07caf186f2c58e248a77ce60/transaction/_transaction.py#L401) logs a *critical* error, preceded by the comment “*do we need to make this warning stronger?*”.
- That’s the way does it (for non-two-phase sessions.)