### PR TITLE
Allow optionally ignoring transient smtp errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 Change history
 ~~~~~~~~~~~~~~
 
-Unreleased
-----------
+4.3 (unreleased)
+----------------
 
-- Add support for Python 3.4, PyPy3.
+- Drop support for Python 2.6 and 3.2.
+
+- Add support for Python 3.4 and 3.5.
+
 - Add ignore_transient parameter to QueueProcessor, to prevent raising
   temporary errors in some situations.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Unreleased
 ----------
 
 - Add support for Python 3.4, PyPy3.
+- Add ignore_transient parameter to QueueProcessor, to prevent raising
+  temporary errors in some situations.
 
 4.2 (2014-02-17)
 ----------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -112,3 +112,5 @@ Contributors
 - Jonathan Vanasco, 2013/03/19
 
 - Patrick Strawderman, 2013/11/15
+
+- Carlos de la Guardia, 2016/12/08

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -76,6 +76,18 @@ in the queue.  To see all options available:
 .. code-block:: bash
 
   $ bin/qp --help
+  
+The QueueProcessor used by the console utility can also be called from Python:
+
+.. code-block:: python
+
+   qp = QueueProcessor(mailer, queue_path, ignore_transient=True)
+   qp.send_messages()
+   
+The `ignore_transient` parameter, when True, will cause the queue processor to
+ignore transient errors (any error code not between 500 and 599). This is
+useful when monitoring systems are used, to prevent filling the error reports
+with temporary errors.
 
 
 Direct SMTP Delivery

--- a/repoze/sendmail/queue.py
+++ b/repoze/sendmail/queue.py
@@ -240,11 +240,9 @@ class QueueProcessor(object):
                     _os_link(filename, rejected_filename)
                 else:
                     # Log an error and retry later
-                    self.log.error(
-                        "Postponing sending email from %s to %s due to"
-                        " a transient error: %s",
-                        fromaddr, ", ".join(toaddrs), e.args)
-                    if not ignore_transient:
+                    if self.ignore_transient:
+                        return
+                    else:
                         raise
 
             try:


### PR DESCRIPTION
Raising an exception triggers alarms in some monitoring systems, even when the message is usually delivered later. Having the option of not raising exceptions in these cases can prevent this.
