### PR TITLE
Fixes queued delivery script on Python 3.5

### DIFF
--- a/repoze/sendmail/queue.py
+++ b/repoze/sendmail/queue.py
@@ -333,6 +333,7 @@ class ConsoleApp(object):
         self.script_name = argv[0]
         self._load_config()
         self._process_args(argv[1:])
+        debug_smtp = 1 if self.debug_smtp else 0
         self.mailer = SMTPMailer(
             hostname=self.hostname,
             port=self.port,
@@ -341,7 +342,7 @@ class ConsoleApp(object):
             no_tls=self.no_tls,
             force_tls=self.force_tls,
             ssl=self.ssl,
-            debug_smtp=self.debug_smtp,
+            debug_smtp=debug_smtp,
             )
         
     def main(self):
@@ -454,7 +455,7 @@ class ConsoleApp(object):
         self.no_tls = boolean(config.get(section, "no_tls"))
         self.ssl = boolean(config.get(section, "ssl"))
         self.queue_path = string_or_none(config.get(section, "queue_path"))
-        self.debug_smtp = string_or_none(config.get(section, "debug_smtp"))
+        self.debug_smtp = boolean(config.get(section, "debug_smtp"))
 
 
     def _error_usage(self):


### PR DESCRIPTION
`bin/qp --config qp.ini maildir` fails on Python 3.5 because console script uses string value in `connection.set_debuglevel` while Python expects integer value (0/1/2):

```
Traceback (most recent call last):
  File "/Users/tobias/projects/mrt/lib/python3.5/site-packages/repoze/sendmail/queue.py", line 232, in _send_message
    self.mailer.send(fromaddr, toaddrs, message)
  File "/Users/tobias/projects/mrt/lib/python3.5/site-packages/repoze/sendmail/mailer.py", line 75, in send
    code, response = connection.ehlo()
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/smtplib.py", line 439, in ehlo
    self.putcmd(self.ehlo_msg, name or self.local_hostname)
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/smtplib.py", line 366, in putcmd
    self.send(str)
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/smtplib.py", line 344, in send
    if self.debuglevel > 0:
TypeError: unorderable types: str() > int()
```