### PR TITLE
Fix #41 (set charset of messages part of a multipart/alternative message correctly)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ Change history
 
 - TBD
 
+4.4.2 (2019-02-20)
+------------------
+
+- Fix setting charset for attached messages in a multipart/alternative message
+  (issue #41)
+
 4.4.1 (2017-04-21)
 ------------------
 

--- a/repoze/sendmail/encoding.py
+++ b/repoze/sendmail/encoding.py
@@ -71,7 +71,7 @@ def cleanup_message(message,
 
     payload = message.get_payload()
     if payload and isinstance(payload, text_type):
-        charset = message.get_charset()
+        charset = message.get_content_charset()
         if not charset:
             charset, encoded = best_charset(payload)
             message.set_payload(payload, charset=charset)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ README = _read_file('README.rst')
 CHANGES = _read_file('CHANGES.rst')
 
 setup(name='repoze.sendmail',
-      version = '4.5.dev0',
+      version = '4.4.2',
       url='http://www.repoze.org',
       license='ZPL 2.1',
       description='Repoze Sendmail',


### PR DESCRIPTION
More info in the commit including the fix.
Tests pass.
Ok?

(thanks!)