### PR TITLE
Fix #46 'always send CRLF line endings over SMTP in Python 3'

### DIFF
--- a/repoze/sendmail/encoding.py
+++ b/repoze/sendmail/encoding.py
@@ -1,6 +1,10 @@
 from email import utils
 from email import header
-from email.policy import SMTP
+
+try:
+  from email.policy import SMTP
+except ImportError:
+  SMTP = None
 
 from repoze.sendmail._compat import PY_2
 from repoze.sendmail._compat import text_type
@@ -101,8 +105,10 @@ def encode_message(message,
     The return is a byte string of the whole message.
     """
     cleanup_message(message)
-    return message.as_string(policy=SMTP).encode('ascii')
-    # Or messsage.as_bytes(policy=SMTP) ?
+    if SMTP: # Python 3.3+
+      return message.as_bytes(policy=SMTP)
+    else:
+      return message.as_string().encode('ascii')
 
 
 def best_charset(text):

--- a/repoze/sendmail/encoding.py
+++ b/repoze/sendmail/encoding.py
@@ -1,5 +1,6 @@
 from email import utils
 from email import header
+from email.policy import SMTP
 
 from repoze.sendmail._compat import PY_2
 from repoze.sendmail._compat import text_type
@@ -100,7 +101,8 @@ def encode_message(message,
     The return is a byte string of the whole message.
     """
     cleanup_message(message)
-    return message.as_string().encode('ascii')
+    return message.as_string(policy=SMTP).encode('ascii')
+    # Or messsage.as_bytes(policy=SMTP) ?
 
 
 def best_charset(text):


### PR DESCRIPTION
In particular this helps Exchange.