### PR TITLE
Stop swallowing dict returned by stdlib sendmail()

### DIFF
--- a/repoze/sendmail/mailer.py
+++ b/repoze/sendmail/mailer.py
@@ -97,12 +97,15 @@ class SMTPMailer(object):
                     'Mailhost does not support ESMTP but a username '
                     'is configured')
 
-        connection.sendmail(fromaddr, toaddrs, message)
+        # With multiple recipients sendmail() returns a dict that may
+        # contain an error for each recipient.
+        error_dict = connection.sendmail(fromaddr, toaddrs, message)
         try:
             connection.quit()
         except SSLError:
-            # something weird happened while quiting
+            # Something weird happened while quitting.
             connection.close()
+        return error_dict
 
 
 @implementer(IMailer)
@@ -189,4 +192,4 @@ class SendmailMailer(object):
         Expects the same call signature as subprocess.Popen.
         """
         kw['stdin'] = subprocess.PIPE
-        return subprocess.Popen(*args, **kw) 
+        return subprocess.Popen(*args, **kw)


### PR DESCRIPTION
One quirk of the [sendmail method of Python stdlib](https://docs.python.org/3/library/smtplib.html#smtplib.SMTP.sendmail) is that it may return a dictionary of errors.  This can happen when there are multiple recipients in the message being sent.  The docs tell us:

_(...) if this method does not raise an exception, then someone should get your mail. If this method does not raise an exception, it returns a dictionary, with one entry for each recipient that was refused. Each entry contains a tuple of the SMTP error code and the accompanying error message sent by the server._

It is necessary to allow that dictionary to reach the application, since it is the only code that knows how to deal with that situation.  This is so clearly the case that the library pyramid_mailer, which reuses repoze.sendmail, [assumes there's a return value and does return it to the application](https://github.com/Pylons/pyramid_mailer/blob/master/pyramid_mailer/mailer.py#L429).

Existing tests pass but I did not add a new test.  If you think I should, please let me know.